### PR TITLE
Harden SDK logging, HTTP defaults, and CI supply chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 ## ZeroBounce Java SDK
 
+
+## Security
+
+- Keep API keys on a trusted server. Do not embed them in mobile apps or browser JavaScript that untrusted users can inspect.
+- Custom API base URLs (when supported) must use `https://`. Do not pass end-user-controlled hosts into those settings.
+- Request URLs include `api_key` as a query parameter (ZeroBounce API contract). Do not log full request URLs or enable payload debug logging in production.
+
 [![Maven Central](https://img.shields.io/maven-central/v/com.zerobounce.java/zerobouncesdk?label=Latest%20release)](https://mvnrepository.com/artifact/com.zerobounce.java/zerobouncesdk)
 
 This SDK contains methods for interacting easily with ZeroBounce API.

--- a/zero-bounce-sdk/src/main/java/com/zerobounce/ZeroBounceSDK.java
+++ b/zero-bounce-sdk/src/main/java/com/zerobounce/ZeroBounceSDK.java
@@ -77,6 +77,8 @@ public class ZeroBounceSDK {
         logPayloads = enabled;
     }
 
+    private static final int DEFAULT_TIMEOUT_MILLIS = 120_000;
+
     String apiBaseUrl = "https://api.zerobounce.net/v2";
     private final String bulkApiBaseUrl = "https://bulkapi.zerobounce.net/v2";
     private final String bulkApiScoringBaseUrl = "https://bulkapi.zerobounce.net/v2/scoring";
@@ -97,13 +99,13 @@ public class ZeroBounceSDK {
     /**
      * Initializes the SDK.
      * <p>
-     * [timeoutInMillis] is set to 0 (no timeout by default)
+     * [timeoutInMillis] is set to 120000 (120 seconds) by default
      *
      * @param apiKey the API key
      */
     public void initialize(String apiKey) {
         this.apiKey = apiKey;
-        timeoutInMillis = 0;
+        timeoutInMillis = DEFAULT_TIMEOUT_MILLIS;
     }
 
     /**
@@ -125,8 +127,16 @@ public class ZeroBounceSDK {
      */
     public void initialize(String apiKey, @Nullable String apiBaseUrl) {
         this.apiKey = apiKey;
+        timeoutInMillis = DEFAULT_TIMEOUT_MILLIS;
         if (apiBaseUrl != null) {
+            requireHttpsUrl(apiBaseUrl);
             this.apiBaseUrl = apiBaseUrl;
+        }
+    }
+
+    static void requireHttpsUrl(String url) {
+        if (url == null || !url.regionMatches(true, 0, "https://", 0, 8)) {
+            throw new IllegalArgumentException("apiBaseUrl must be an https:// URL");
         }
     }
 
@@ -1181,6 +1191,7 @@ public class ZeroBounceSDK {
             logDebug("ZeroBounceSDK::sendRequest executing " + httpMethod + " " + urlPath);
 
             con.setConnectTimeout(timeoutInMillis);
+            con.setReadTimeout(timeoutInMillis);
 
             int status = con.getResponseCode();
             logDebug("ZeroBounceSDK::sendRequest status: " + status);

--- a/zero-bounce-sdk/src/test/java/com/zerobounce/ZeroBounceSDKTest.java
+++ b/zero-bounce-sdk/src/test/java/com/zerobounce/ZeroBounceSDKTest.java
@@ -62,6 +62,18 @@ public class ZeroBounceSDKTest {
     }
 
     @Test
+    public void requireHttpsUrl_rejectsHttp() {
+        assertThrows(IllegalArgumentException.class, () -> ZeroBounceSDK.requireHttpsUrl("http://example.com"));
+        assertThrows(IllegalArgumentException.class, () -> ZeroBounceSDK.requireHttpsUrl("file:///etc/passwd"));
+        ZeroBounceSDK.requireHttpsUrl("https://api.zerobounce.net/v2");
+    }
+
+    @Test
+    public void initialize_rejectsNonHttpsBaseUrl() {
+        assertThrows(IllegalArgumentException.class, () -> zeroBounceSDK.initialize(API_KEY, "http://evil.example"));
+    }
+
+    @Test
     public void validateEmail_ReturnsSuccess() throws Exception {
         // Prepare mock response and add it to the server
         String responseJson = """


### PR DESCRIPTION
## Summary

- Require `https://` for custom base URLs
- Default HTTP timeout to 120s (was 0 / infinite)
- Unit tests for the URL gate

This is **not** a version bump or registry publish. Cut a separate `release-sdk` pass after merge if the hardening should ship to package registries.

## Test plan

- [ ] SDK unit tests (Docker matrix / host for iOS)
- [ ] Confirm no live API key is logged or committed
- [ ] Confirm custom `http://` / `file:` base URLs are rejected (except documented loopback test exceptions)


Made with [Cursor](https://cursor.com)